### PR TITLE
Add audit documentation for Django apps

### DIFF
--- a/docs/PROJECT_RECOMMENDATIONS.md
+++ b/docs/PROJECT_RECOMMENDATIONS.md
@@ -1,0 +1,34 @@
+# Project Recommendations
+
+## Executive Summary
+- **Overall health:** 🔴 Red — strong feature velocity but production-readiness is undermined by environment misconfiguration, uneven architecture, and limited observability.
+- **Critical themes:** (1) Consolidate domain boundaries (quests/activities/courses) to avoid duplicated state. (2) Harden security and tenancy controls. (3) Establish testing/observability baselines. (4) Introduce environment separation and automation for ops.
+- **Success criteria:** A single authoritative quest/activity pipeline, consistent permissions across apps, reproducible environments with protected secrets, and automated testing/monitoring integrated into CI/CD.
+
+## Architecture & Platform
+- **App boundaries:** Decide ownership of activities vs. quests vs. responses, moving duplicated models into a single module with published interfaces. Adopt modular settings (base/dev/prod) and enforce enabling/disabling of legacy code via feature flags.
+- **Infrastructure:** Externalize SECRET_KEY and provider credentials, add environment-specific settings modules, and define deployment runbooks for ASGI (Channels + Daphne). Introduce CI jobs running tests/linters and infrastructure for Celery/async tasks where needed.
+- **Data strategy:** Plan migrations to unify attempt/submission data, quest legacy->V2 conversions, and agenda versioning. Define retention/archive policies for transcripts and responses, including GDPR/PII considerations.
+
+## Product Surface
+- **API governance:** Generate OpenAPI schema, document all endpoints, and version APIs where migrations are pending. Establish change management for frontend consumers.
+- **User experience:** Ensure consistent session handling between courses, activities, and chat; align continue/restart flows and provide user-facing messaging for expirations.
+- **Compliance & privacy:** Formalize encryption key storage, audit logging, and data retention schedules (chat transcripts, course responses, profile photos). Review wildcard CORS/ALLOWED_HOSTS usage.
+
+## Engineering Excellence
+- **Testing:** Implement baseline unit/integration tests across apps (auth, quest lifecycle, session flows). Require tests in CI before deploy. Adopt factories/fixtures and consider contract tests for frontend integration.
+- **Observability:** Standardize logging (structured JSON), add metrics for key flows (quest enrollment, session completions, chat usage), and integrate error tracking (Sentry or similar).
+- **Developer experience:** Provide comprehensive README (this doc + per-app summaries), docker-compose or scripts for local setup, linting/formatting tools, and documented code review guidelines.
+
+## Roadmap
+1. **Foundation (0-2 weeks):** Split settings into environments, secure secrets, add authentication throttling, and publish documentation of current architecture (completed with this audit). Kick off baseline test suite.
+2. **Stabilization (1-2 months):** Migrate quests to V2, consolidate activity/session models, implement observability stack, and introduce async worker for background jobs. Harden permissions/org scoping across apps.
+3. **Maturation (Quarter+):** Automate data retention/compliance workflows, expand analytics/reporting, and invest in admin tooling/feature flags for faster experimentation.
+
+## Ownership & Follow-Through
+- **Team assignments:**
+  - Platform/Infra: settings refactor, secrets management, CI/CD and observability.
+  - Product Engineering: domain consolidation (quests/activities/responses) and API governance.
+  - Security/Compliance: encryption key strategy, auditing, retention policies.
+- **Dependencies:** Requires buy-in from frontend team for API changes, infrastructure support for secrets/observability tooling, and product alignment on migration timelines.
+- **Tracking:** Establish fortnightly architecture syncs, maintain a remediation Kanban board, and monitor KPIs (session success rate, auth error rate, quest migration progress).

--- a/docs/PROJECT_SUMMARY.md
+++ b/docs/PROJECT_SUMMARY.md
@@ -1,0 +1,38 @@
+# Project Overview
+
+## Vision & Scope
+- **Product intent:** Deliver an AI-assisted learning platform combining quests, courses, chat-based assistance, and activity sessions for users and organizations.
+- **System boundaries:** This repo houses the Django backend (REST APIs, Channels WebSockets, management commands). External dependencies include third-party LLM providers and a separate frontend deployment.
+- **Deployment targets:** Configured for Railway hosting (Procfile, railway.toml) with ASGI support via Daphne/Uvicorn, plus local development using Django runserver.
+
+## Application Map
+- **Installed Django apps:**
+  - `apps.users` — authentication, profile management, quest onboarding.
+  - `apps.courses` — course hierarchy/skill tree and progress tracking.
+  - `apps.quests` — quest management (legacy + V2 enrollment system).
+  - `apps.responses` — course assessment sessions and AI response storage.
+  - `apps.chat` — configurable LLM chat sessions with WebSocket streaming.
+  - `apps.organizations` — tenant administration and admin relationships.
+  - (Commented) `apps.activities` — comprehensive activity authoring/sessions; code remains but app not installed.
+- **Shared libraries:** `mysite` project with custom middleware, debug helpers, and centralized settings; DRF, SimpleJWT, and Django Channels provide cross-cutting infrastructure.
+- **External integrations:** LLM providers (Anthropic, OpenAI) via chat app, PostgreSQL database, JWT auth, and optional storage for media/profile photos.
+
+## Runtime Architecture
+- **Request lifecycle:** ASGI application (`mysite.asgi`) enables HTTP and WebSocket handling. Middleware stack includes CORS, session, and WhiteNoise for static assets. REST endpoints use DRF routers across apps.
+- **Data layer:** PostgreSQL via `psycopg2` stores relational data; JSONFields widely capture dynamic metadata. No caching layer configured.
+- **Background work:** Management commands support data seeding, cleanup, and migration tasks; no Celery or async workers configured despite asynchronous needs (quest onboarding, session cleanup).
+
+## Configuration & Environments
+- **Settings strategy:** Single `settings.py` mixes development/production flags (DEBUG=True, hardcoded secret key) with Railway-specific overrides; environment variables supply database credentials.
+- **Secrets management:** SECRET_KEY and provider keys not externalized; `.env` loading supported locally but production relies on environment variables without rotation guidance.
+- **Feature flags:** Implicit toggles through code comments (e.g., legacy vs. V2 quests, activities) and environment checks; no centralized feature flag system.
+
+## Operational Considerations
+- **Security posture:** Uses SimpleJWT for auth but lacks rate limiting; organization scoping inconsistently enforced. CSRF/CORS configured for Railway domains with wildcard allowances.
+- **Observability:** Minimal structured logging/metrics; relies on ad hoc logs within services and serializers. No monitoring/alerting integration in repo.
+- **Scalability:** Channels enables WebSockets but no horizontal scaling guidance; session-heavy apps store state in DB without caching or task queues.
+
+## Current Initiatives
+- **Active migrations/refactors:** Ongoing migration from legacy quests/activities attempts to session/submission architectures; activities app partially merged into quests but still maintained separately.
+- **Known gaps:** Sparse documentation (previously only template README), limited automated tests across apps, missing permission checks, and unclear data governance (agenda versions, encryption keys).
+- **Opportunities:** Standardize architecture across apps, improve environment separation, adopt asynchronous workers for heavy onboarding, and implement observability/tooling to support production readiness.

--- a/docs/apps/activities/RECOMMENDATIONS.md
+++ b/docs/apps/activities/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Activities App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🔴 Red — overlapping legacy and new session architectures, limited test coverage, and sparse permission checks create high maintenance risk.
+- **Top risks:** Data divergence between `Attempt`/`Response` and `ActivitySession`/`ActivitySubmission`, unclear API surface across `urls.py` vs. `session_urls.py`, and ad hoc management commands operating on production data.
+- **Immediate wins:** Document authoritative API (session vs. legacy), add permission classes to ViewSets, and instrument cleanup jobs for observability.
+
+## Architecture & Design
+- **Boundaries:** Decide whether quest orchestration lives here or in `apps.quests`; migrate quest-related models (`QuestDefinition`, `QuestInstance`) to quests to reduce duplication.
+- **Domain model:** Consolidate on the session/submission schema by backfilling submissions from attempts and freezing legacy writers; introduce explicit status enums instead of string literals.
+- **State management:** Centralize TTL/cleanup policy in settings and expose metrics for expired sessions rather than embedding constants in services.
+
+## Code Quality & Testing
+- **Testing strategy:** Add factories for `Activity`, `ActivitySession`, and `ActivitySubmission`; cover `ActivitySessionService` continue/restart paths and management commands.
+- **Modularity:** Extract serializer validation logic out of views into dedicated validators to simplify `views.py`; break large services into focused collaborators.
+- **Error handling:** Ensure session navigation gracefully handles missing page content with typed exceptions mapped to 4xx responses.
+
+## API & Integration Surface
+- **Contracts:** Publish OpenAPI/DRF schema for both authoring and session endpoints; version the session API if the legacy endpoints must remain temporarily.
+- **Security:** Apply organization-based permission classes and user ownership checks in ViewSets; add throttling for session start/continue actions to prevent abuse.
+- **Performance:** Prefetch related pages/blocks in serializer queries to avoid N+1 patterns when hydrating activity detail responses.
+
+## Operations & Tooling
+- **Monitoring:** Emit structured logs for session lifecycle events and cleanup jobs; add metrics for active sessions, completion times, and expirations.
+- **Automation:** Schedule `cleanup_expired_sessions` via Celery/cron with alerting on failures; gate `create_comprehensive_demo` behind environment checks.
+- **Documentation:** Provide runbooks for migrating legacy attempts and for interpreting the new submission tables.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Lock down permissions, publish authoritative API docs, and add smoke tests for session lifecycle.
+2. **Next (1-2 months):** Complete migration off legacy attempt models, refactor services into smaller units, and implement metrics/alerts for session cleanup.
+3. **Later (Quarter+):** Explore content versioning workflows (draft/publish with approvals) and richer analytics exports built on the consolidated submission schema.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Align with quests team on ownership of quest instance data and with frontend on endpoint deprecation timelines.
+- **Blocking issues:** Requires historical attempt data audit before deletion and potential data warehouse consumers review.
+- **Definition of done:** All consumers use session/submission APIs, automated cleanup is observable, and tests cover core session flows.

--- a/docs/apps/activities/SUMMARY.md
+++ b/docs/apps/activities/SUMMARY.md
@@ -1,0 +1,53 @@
+# Activities App Summary
+
+## Purpose & Scope
+- **Primary mission:** Manage authored learning activities, their page/block structure, and user execution lifecycle from session to submission.
+- **Core consumers:** Internal quest orchestration (apps.quests), course/response analytics, and frontend clients hitting REST endpoints for authoring and playthrough.
+- **Key entry points:** DRF routers exposed in `urls.py` for authoring/results and `session_urls.py` for live sessions, alongside management commands for demo data and data migration.
+
+## Domain Model
+- **Primary models:**
+  - `Activity`, `ActivityVersion`, `Page`, and `Block` provide a versioned hierarchy of authored content (`models.py`).
+  - `QuestDefinition`, `QuestInstance`, and `Attempt` legacy quest/attempt tracking (`models.py`).
+  - `ActivitySession`, `ActivitySubmission`, and `SubmissionResponse` implement the newer session/submission split (`models.py`).
+- **Supporting data:**
+  - `MediaAsset` and `QuestionPackage` hold reusable assets and metadata (`models.py`).
+  - `PageProgress` and `Response` capture granular attempt data (`models.py`).
+  - Session-specific persistence lives in `session_models.py` (e.g., `ActivitySession`, `ActivityCompletion`, `SessionAttempt`).
+- **External relationships:** Activities link to `organizations.Organization` for ownership and to the custom `User` model for quest/session tracking (`models.py`).
+
+## Application Structure
+- **API layer:**
+  - Authoring/results ViewSets in `views.py` registered via `urls.py` for CRUD and analytics (`urls.py`).
+  - Session-oriented endpoints (start/continue, navigation, analytics) in `session_views.py` routed by `session_urls.py`.
+- **Business logic:**
+  - `services.py` handles authoring-side orchestration (publishing, demo data).
+  - `session_services.py` centralizes the new session lifecycle and completion workflow.
+  - `session_services.py` and `services.py` rely heavily on query helpers embedded in models.
+- **Background/operations:**
+  - Management commands to create demo content, migrate old attempts, and clean expired sessions (`management/commands`).
+- **Configuration:**
+  - Relies on quest/activity feature toggles implied by comments (e.g., new session flow) and cleanup intervals baked into services.
+
+## Data & Control Flow
+- **Inbound:** Requests enter via DRF ViewSets for CRUD or via dedicated session actions (`urls.py`, `session_urls.py`). Validation is mostly serializer-driven, with business rules in services.
+- **Processing:** Authoring operations go through serializer/model logic; session operations orchestrate `ActivitySessionService` to manage continue/restart decisions and persist progress (`session_services.py`).
+- **Outbound:** Responses return DRF serializer payloads, while background commands create/mutate data for other apps (quests, courses). Session completion writes `ActivitySubmission` records consumed by reporting endpoints (`views.py`).
+
+## Integration Points
+- **Inter-app dependencies:**
+  - Quests rely on `Activity` metadata when assembling enrollments (`quests` services).
+  - Responses/courses read submission data for analytics and unlocking logic.
+  - Organizations enforce tenant scoping for authored content.
+- **External services:** No direct third-party calls; assumes storage/backends for media via keys in `MediaAsset`.
+- **Shared libraries:** Uses Django REST Framework and Django ORM patterns shared across apps.
+
+## Operational Notes
+- **Statefulness:** Tracks both legacy `Attempt`/`Response` records and newer `ActivitySession`/`ActivitySubmission` data, leading to overlapping state machines.
+- **Security & privacy:** Access control largely delegated to DRF defaults; organization ownership and user foreign keys enforce scope but lack explicit permission classes.
+- **Observability:** Logging hooks exist in services, but no structured metrics or analytics instrumentation beyond manual fields.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Coexistence of legacy attempt model and new session/submission architecture; `session_urls.py` describes a parallel API surface still stabilizing.
+- **Planned migrations:** `management/commands/migrate_completed_attempts.py` hints at migrating historical attempts into the new submission tables.
+- **Open questions:** How/when the legacy quest attempt stack will be deprecated, and whether organizations/quests fully adopt the new APIs.

--- a/docs/apps/chat/RECOMMENDATIONS.md
+++ b/docs/apps/chat/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Chat App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🟠 Yellow — core abstractions are in place, but gaps in auth, observability, and provider management threaten reliability.
+- **Top risks:** Missing access controls on REST/WebSocket endpoints, lack of automated TTL cleanup for `ChatSession`, and hardcoded provider defaults without environment segregation.
+- **Immediate wins:** Enforce DRF permissions, add WebSocket authentication middleware, and schedule a job to deactivate expired sessions.
+
+## Architecture & Design
+- **Boundaries:** Separate provider configuration from runtime session state; consider a dedicated module for preset definitions that can be versioned.
+- **Domain model:** Normalize model/provider parameters to avoid arbitrary JSON blobs and ease validation; persist provider response metadata in a structured form.
+- **State management:** Move TTL durations and session policies into settings, exposing a cron/management command for cleanup and metrics.
+
+## Code Quality & Testing
+- **Testing strategy:** Add tests for `ChatSessionService` create/update flows, conversation streaming, and analytics aggregations using mocked LLM clients.
+- **Modularity:** Extract provider-specific logic from `conversation_service.py` into adapters; tighten typing around processors to avoid silent failures.
+- **Error handling:** Introduce structured exceptions for provider failures and map them to meaningful HTTP/WebSocket error payloads.
+
+## API & Integration Surface
+- **Contracts:** Document REST endpoints and message formats for WebSocket clients; version presets so clients can detect breaking changes.
+- **Security:** Require authenticated WebSocket connections (token/cookie), validate ownership on every session/message call, and scrub sensitive parameters before persisting.
+- **Performance:** Implement pagination for session history, index `ChatMessage` queries appropriately (already partially covered) and batch analytics queries.
+
+## Operations & Tooling
+- **Monitoring:** Emit metrics for active sessions, message latency, and provider error rates; integrate with logging/alerting for provider outages.
+- **Automation:** Provide management commands for rehydrating presets and rotating provider credentials; run TTL cleanup as scheduled job.
+- **Documentation:** Maintain runbooks for onboarding new providers and troubleshooting streaming failures.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Add authentication/authorization to all endpoints, implement TTL cleanup, and create contract docs for REST/WebSocket APIs.
+2. **Next (1-2 months):** Refactor provider adapters with test coverage and add observability hooks (metrics/logging dashboards).
+3. **Later (Quarter+):** Build UI/admin tooling for preset management and experiment with conversation summarization/storage policies.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Align with security/compliance on storage of LLM prompts/responses and with frontend on auth changes.
+- **Blocking issues:** Need environment secrets for providers and decision on persistence retention for privacy compliance.
+- **Definition of done:** Auth enforced, sessions auto-expire without manual intervention, and provider integrations are observable and tested.

--- a/docs/apps/chat/SUMMARY.md
+++ b/docs/apps/chat/SUMMARY.md
@@ -1,0 +1,40 @@
+# Chat App Summary
+
+## Purpose & Scope
+- **Primary mission:** Provide multi-provider LLM chat experiences with configurable presets, analytics, and WebSocket streaming.
+- **Core consumers:** Frontend chat clients over REST and WebSockets, analytics dashboards, and background processors for conversation control.
+- **Key entry points:** REST endpoints in `views.py`, session management services in `services.py`, conversation orchestration via `conversation_service.py`, and Channels consumers in `websocket_consumers.py` mapped through `websocket_urls.py`.
+
+## Domain Model
+- **Primary models:** `ChatSession` stores per-user chat sessions with TTL and dynamic configuration, while `ChatMessage` persists individual conversation turns (`models.py`).
+- **Supporting data:** Analytics helpers in `analytics.py` compute session statistics; presets and provider specs live in `presets.py` and `providers.py`.
+- **External relationships:** Sessions tie to the custom `User` model; configuration references external LLM providers defined in `llm_clients.py`.
+
+## Application Structure
+- **API layer:** `views.py` exposes DRF endpoints for creating/updating sessions and retrieving transcripts; routers are registered in `urls.py`.
+- **Business logic:**
+  - `services.py` coordinates session lifecycle, validation through `SessionConfigValidator`, and persistence.
+  - `conversation_service.py` manages turn handling, safety filters, and provider dispatch.
+  - `control_service.py` and `processors.py` plug into conversation orchestration for tool outputs and context enrichment.
+- **Background/operations:** No Celery tasks; relies on TTL expiration and management via services. WebSockets provide live streaming through Channels consumers.
+- **Configuration:** Provider and context defaults defined in code (`providers.py`, `presets.py`); environment variables power actual API keys via `llm_clients.py`.
+
+## Data & Control Flow
+- **Inbound:** REST and WebSocket requests create/update sessions and submit messages. Configuration is validated before sessions persist.
+- **Processing:** Messages flow through conversation services that select providers, apply context/prompt templates, and stream completions back to clients.
+- **Outbound:** Responses are persisted as `ChatMessage` rows and emitted to clients via HTTP responses or WebSocket events; analytics endpoints aggregate stats for dashboards.
+
+## Integration Points
+- **Inter-app dependencies:** Minimal direct coupling aside from using the shared `User` model and potential references from courses/quests for agenda generation.
+- **External services:** Connects to third-party LLM providers (Anthropic, OpenAI) via `llm_clients.py` with provider-specific configuration (`providers.py`).
+- **Shared libraries:** Uses DRF, Django Channels, and HTTP clients (`httpx`) for streaming.
+
+## Operational Notes
+- **Statefulness:** Sessions expire based on `expires_at`; TTL management occurs in model `save()` and service methods but lacks centralized scheduler.
+- **Security & privacy:** Sessions rely on user ownership but lack explicit permission classes; configuration may include sensitive provider parameters stored as JSON.
+- **Observability:** Logging is scattered; analytics helpers exist but no integration with metrics/tracing systems.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Supports preset-based configuration and ad hoc overrides; conversation processors enable experimental tool integrations.
+- **Planned migrations:** Comments suggest migrating to provider-agnostic configs and better validation but no formal migration path documented.
+- **Open questions:** How session TTL cleanup occurs in production and how WebSocket auth is enforced across environments.

--- a/docs/apps/courses/RECOMMENDATIONS.md
+++ b/docs/apps/courses/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Courses App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🟠 Yellow — model is simple but critical logic is duplicated across serializers and responses integration, with little validation or auditing.
+- **Top risks:** Agenda markdown is unversioned despite driving assessments, progress defaults are hardcoded, and no guardrails prevent cross-tenant access.
+- **Immediate wins:** Introduce organization scoping, centralize agenda parsing/version hashes, and add tests for `skill_tree` and `update_progress` actions.
+
+## Architecture & Design
+- **Boundaries:** Clarify whether agenda ownership belongs here or in responses; expose a dedicated agenda service rather than having responses parse raw markdown.
+- **Domain model:** Track agenda versions and metadata on `Course` to prevent silent schema drifts; consider a separate table for skill tree positioning vs. course content.
+- **State management:** Move default status rules (root unlocked, parent gating) into declarative configuration, and expose signals/events when progress changes.
+
+## Code Quality & Testing
+- **Testing strategy:** Create factories for `Course` hierarchies and `UserCourseProgress`; cover serializer helpers and view actions with DRF tests.
+- **Modularity:** Extract progress default logic into a reusable utility to avoid duplication between serializer and views; avoid querying inside serializer getters repeatedly.
+- **Error handling:** Validate agenda presence before creating sessions in responses; return meaningful errors when progress updates violate gating rules.
+
+## API & Integration Surface
+- **Contracts:** Document the `skill_tree` response shape for frontend clients; plan versioning if agenda schema or positioning changes.
+- **Security:** Enforce organization/role-based permissions on course access and updates; restrict who can mutate progress outside automated flows.
+- **Performance:** Prefetch child relationships and progress in one query (already partially done); consider caching the skill tree for anonymous reads.
+
+## Operations & Tooling
+- **Monitoring:** Log/audit progress changes and expose metrics for course completion funnels.
+- **Automation:** Provide management commands for seeding/updating course catalogs and validating agenda markdown.
+- **Documentation:** Maintain authoring guidelines for agenda format and positioning rules.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Add permission checks, write unit tests, and document agenda/skill-tree contracts.
+2. **Next (1-2 months):** Introduce agenda versioning with migration support and centralize gating rules.
+3. **Later (Quarter+):** Integrate analytics dashboards and automation for large-scale catalog updates.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Align with responses team on agenda ownership and with organizations team on tenancy requirements.
+- **Blocking issues:** Need clarity on multi-tenant requirements before designing permission scheme.
+- **Definition of done:** Agenda changes are versioned/audited, progress updates respect organization boundaries, and automated tests protect gating logic.

--- a/docs/apps/courses/SUMMARY.md
+++ b/docs/apps/courses/SUMMARY.md
@@ -1,0 +1,37 @@
+# Courses App Summary
+
+## Purpose & Scope
+- **Primary mission:** Model course hierarchy/skill tree data and track user progress states to unlock learning paths.
+- **Core consumers:** Frontend constellation/skill-tree visualizations, responses app for agenda parsing, and admin tooling for course maintenance.
+- **Key entry points:** Read-only DRF `CourseViewSet` with custom actions, user progress endpoints in `views.py`, and serializers exposing course graph metadata (`serializers.py`).
+
+## Domain Model
+- **Primary models:** `Course` defines hierarchical course nodes with positional metadata, and `UserCourseProgress` records per-user status transitions (`models.py`).
+- **Supporting data:** Course agenda markdown stored on `Course.agenda` feeds agenda parsing in `apps.responses`.
+- **External relationships:** Progress updates unlock related content in `apps.responses` via shared foreign keys; course completion affects child course availability.
+
+## Application Structure
+- **API layer:** `CourseViewSet` (read-only) with `skill_tree` aggregation and `update_progress` mutation actions, requiring authentication (`views.py`).
+- **Business logic:** Serializer helpers compute child IDs and derive user status from progress records (`serializers.py`); model methods provide helper lookups.
+- **Background/operations:** No scheduled jobs; progression automation occurs synchronously inside model helpers.
+- **Configuration:** Depends on implicit rules (root courses unlocked by default) encoded in serializer/view logic rather than settings.
+
+## Data & Control Flow
+- **Inbound:** Authenticated API requests fetch the course tree or update a specific course's progress state.
+- **Processing:** Views assemble the full course list, enrich with user progress, and compute defaults when no records exist; updates adjust `UserCourseProgress` and timestamps.
+- **Outbound:** Responses deliver serialized course graphs with per-user status; progress updates return serialized progress records.
+
+## Integration Points
+- **Inter-app dependencies:** `apps.responses` reads course agenda content and updates `UserCourseProgress` upon session completion; `apps.quests` may reference course structure for activity unlocks.
+- **External services:** None directly; data is stored in PostgreSQL.
+- **Shared libraries:** Utilizes DRF serializers and viewsets common across the project.
+
+## Operational Notes
+- **Statefulness:** Progress state is persisted per user; no caching layer. Agenda markdown can drift from parsed snapshots maintained elsewhere.
+- **Security & privacy:** Requires authentication but lacks fine-grained authorization (e.g., organization scoping).
+- **Observability:** No analytics or logging beyond default DRF logging; progress changes are not audited.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Manual progress updates through API vs. automatic updates triggered by responses app; agenda parsing implies future automated unlock logic.
+- **Planned migrations:** None explicit; potential restructuring hinted by dependence on agenda parsing for question counts.
+- **Open questions:** Governance of course agenda format, versioning, and how multi-tenant organizations should isolate course catalogs.

--- a/docs/apps/organizations/RECOMMENDATIONS.md
+++ b/docs/apps/organizations/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Organizations App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🟢 Green leaning Yellow — domain is straightforward but lacks enforcement and observability required for multi-tenant production.
+- **Top risks:** Absence of role-based authorization, no audit of membership changes, and organization scoping not enforced in dependent apps.
+- **Immediate wins:** Add admin-only permissions to the ViewSet, emit audit logs on membership/default changes, and document how organization context should be propagated.
+
+## Architecture & Design
+- **Boundaries:** Establish clear ownership of organization membership updates (e.g., via dedicated services) instead of scattering logic across user methods and views.
+- **Domain model:** Expand `OrganizationAdmin` with explicit role enum and optional status flags; consider soft-delete/audit tables for compliance.
+- **State management:** Introduce signals or hooks when default organization changes to update cached context in other apps.
+
+## Code Quality & Testing
+- **Testing strategy:** Add API tests covering admin status retrieval, default organization updates, and permission failures.
+- **Modularity:** Move business logic from views into a service layer shared with other apps that need to mutate organization relationships.
+- **Error handling:** Provide clearer error codes/messages for inactive organizations or missing admin membership.
+
+## API & Integration Surface
+- **Contracts:** Publish API documentation describing admin status/default endpoints and expected payloads.
+- **Security:** Ensure only organization admins can list organization data; apply throttling and audit logging for membership modifications.
+- **Performance:** Prefetch admin relationships where needed; otherwise current footprint is light.
+
+## Operations & Tooling
+- **Monitoring:** Log all organization membership changes and expose metrics for active organizations vs. suspended ones.
+- **Automation:** Provide management commands to bootstrap organizations, assign admins, and sync permissions from identity providers if applicable.
+- **Documentation:** Create runbooks for onboarding new organizations and handling deactivation workflows.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Implement permission classes and audit logging; write regression tests.
+2. **Next (1-2 months):** Introduce role enums/permissions matrix and propagate organization filters into dependent apps (activities, courses, quests).
+3. **Later (Quarter+):** Integrate with centralized identity/SSO and automate org provisioning.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Align with security/compliance and product owners on role definitions and audit requirements.
+- **Blocking issues:** Need consistent organization concept across apps before enforcing filters.
+- **Definition of done:** Role-based access enforced, membership changes logged, and downstream apps honor organization scoping.

--- a/docs/apps/organizations/SUMMARY.md
+++ b/docs/apps/organizations/SUMMARY.md
@@ -1,0 +1,37 @@
+# Organizations App Summary
+
+## Purpose & Scope
+- **Primary mission:** Represent organizations/tenants, manage admin memberships, and expose APIs for users to inspect or set their default organization.
+- **Core consumers:** Admin UI, other apps checking tenant scope (activities, users), and authentication flows needing organization context.
+- **Key entry points:** Read-only `OrganizationViewSet`, admin status API views (`AdminStatusView`, `SetDefaultOrganizationView`), and serializers for organization/admin relationships (`serializers.py`).
+
+## Domain Model
+- **Primary models:** `Organization` with metadata and activation flags, and `OrganizationAdmin` as the through model linking users to organizations with role/permissions (`models.py`).
+- **Supporting data:** Timestamp mixin provides auditing fields; JSON `permissions` field allows future granularity.
+- **External relationships:** Many-to-many with custom `User` model via the through table; other apps reference organizations for scoping (e.g., activities).
+
+## Application Structure
+- **API layer:** DRF read-only ViewSet for organizations (`views.py`) plus custom APIViews for checking/setting admin status.
+- **Business logic:** Model methods on `User` (in users app) implement admin helpers used by these views; no dedicated services.
+- **Background/operations:** No scheduled jobs or management commands; relies on manual admin operations.
+- **Configuration:** Assumes single shared organization namespace with boolean `is_active` gating.
+
+## Data & Control Flow
+- **Inbound:** Authenticated requests fetch active organizations or update default organization; admin status view aggregates user-related data.
+- **Processing:** Views delegate to user model helper methods and serializers to shape responses; permission checks ensure user is admin before mutation.
+- **Outbound:** Returns serialized organization data and admin metadata for client dashboards.
+
+## Integration Points
+- **Inter-app dependencies:** Tight coupling with `apps.users` for admin helper methods; `apps.activities` references organizations on authored content.
+- **External services:** None.
+- **Shared libraries:** Uses DRF APIView/ViewSet pattern and Django ORM ManyToMany features.
+
+## Operational Notes
+- **Statefulness:** Organization membership persists in relational tables; no caching or TTL concerns.
+- **Security & privacy:** Basic admin check ensures only organization admins can set defaults, but no role-based authorization beyond `role` string.
+- **Observability:** No logging or audit trail for membership changes; relies on database history.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Potential for future differentiated admin roles via `role`/`permissions` fields, but not yet implemented.
+- **Planned migrations:** None noted; expectation of future permission granularity implied by JSON field.
+- **Open questions:** How organization scoping should propagate to other apps and whether non-admin reads should be allowed.

--- a/docs/apps/quests/RECOMMENDATIONS.md
+++ b/docs/apps/quests/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Quests App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🔴 Red — simultaneous legacy and V2 stacks create confusing ownership, high risk of data drift, and heavy maintenance overhead.
+- **Top risks:** Users can exist in both legacy and V2 quest systems, bridges depend on manual commands, and integration with activities lacks transactional guarantees.
+- **Immediate wins:** Freeze legacy quest creation, document V2 as the authoritative path, and add analytics to monitor cross-system divergence.
+
+## Architecture & Design
+- **Boundaries:** Split legacy and V2 code into separate modules/packages with explicit deprecation timeline; isolate shared utilities to avoid circular imports.
+- **Domain model:** Design migrations to convert legacy quests/milestones into templates/enrollments, including data cleanup and mapping of custom fields.
+- **State management:** Introduce status flags/feature switches controlling which quest system is exposed to clients; centralize quest-activity orchestration in a dedicated service.
+
+## Code Quality & Testing
+- **Testing strategy:** Establish fixtures covering both legacy and V2 flows; add integration tests for enrollment lifecycle and activity bridging.
+- **Modularity:** Reduce duplication between `views.py` and `views_v2.py` by extracting shared serializer logic; ensure services encapsulate business rules instead of views.
+- **Error handling:** Implement consistent error responses when prerequisites aren't met; handle race conditions in milestone progression (e.g., multiple clients updating simultaneously).
+
+## API & Integration Surface
+- **Contracts:** Publish roadmap for API consumers describing migration to V2 endpoints; version APIs to avoid breaking clients during transition.
+- **Security:** Enforce organization scoping and sharing permissions for templates/enrollments; audit access to shared quests.
+- **Performance:** Optimize queries with prefetch/select_related (partially done) and consider background jobs for heavy onboarding tasks.
+
+## Operations & Tooling
+- **Monitoring:** Track adoption metrics (legacy vs. V2 usage), quest completion rates, and bridge errors; alert on command failures when seeding quests.
+- **Automation:** Provide idempotent management commands for migrating and seeding V2 data; schedule sync jobs where real-time integration is not feasible.
+- **Documentation:** Maintain runbooks for deprecating legacy quests, including data migration steps and communication plan.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Publish migration plan, gate legacy creation, and add observability to bridge services.
+2. **Next (1-2 months):** Execute migration of existing quests to V2, update frontend clients, and deprecate legacy endpoints.
+3. **Later (Quarter+):** Enhance template authoring tooling and deep integration with activities/courses once a single system remains.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Coordinate with frontend, activities, and product stakeholders on migration timeline and feature parity.
+- **Blocking issues:** Need data mapping for legacy custom fields and assurance from analytics/reporting consumers.
+- **Definition of done:** Legacy endpoints disabled, all quests represented as templates/enrollments, and integration tests cover quest-to-activity lifecycle.

--- a/docs/apps/quests/SUMMARY.md
+++ b/docs/apps/quests/SUMMARY.md
@@ -1,0 +1,42 @@
+# Quests App Summary
+
+## Purpose & Scope
+- **Primary mission:** Coordinate user goal-tracking quests, milestones, and newer enrollment-based quest templates that integrate learning activities.
+- **Core consumers:** Frontend dashboards for personal/shared quests, activities app for quest-driven activity selection, and background demo-seeding commands.
+- **Key entry points:** Legacy `QuestViewSet`/`MilestoneViewSet` in `views.py`, V2 template/enrollment ViewSets in `views_v2.py`, helper routers in `views/`, `dashboard_views.py`, and services bridging activities (`v2_bridge.py`).
+
+## Domain Model
+- **Primary models:**
+  - Legacy `Quest` and `Milestone` representing per-user editable goal boards (`models.py`).
+  - V2 `QuestTemplate`, `MilestoneTemplate`, `QuestEnrollment`, and `MilestoneProgress` supporting shared templates and structured progress tracking (`models.py`).
+- **Supporting data:** Default quest definitions under `default_quests.py`/`default_quests_v2.py`, demo assets in `demo/`, and services for onboarding/bridging activities.
+- **External relationships:** Quests reference `User` and optionally `Activity` structures via JSON. Enrollments can trigger activity sessions via `activities` integration (`v2_bridge.py`).
+
+## Application Structure
+- **API layer:** Multiple DRF routers — legacy `urls.py` for Quest/Milestone endpoints, nested routers in `serializers/` packages, and V2 routers for templates/enrollments.
+- **Business logic:**
+  - `services/` orchestrate quest creation, dashboard aggregation, and integration with activities.
+  - `v2_bridge.py` maps quest progress to activity sessions.
+  - Management commands seed defaults and migrate between versions.
+- **Background/operations:** Demo loaders in `management/`; no continuous jobs but heavy reliance on command-run data seeding.
+- **Configuration:** Many feature toggles implied via comments; V2 adoption is opt-in with fallback to legacy flows.
+
+## Data & Control Flow
+- **Inbound:** Authenticated API requests create/update quests, milestones, enrollments, and trigger status changes via custom actions.
+- **Processing:** Legacy flow mutates `Quest`/`Milestone` directly; V2 flow enrolls users into templates, copies milestone templates into progress rows, and syncs with activities as needed.
+- **Outbound:** Responses deliver quest lists, milestone dashboards, and upcoming/progress data. Bridge services may call activities APIs to launch sessions.
+
+## Integration Points
+- **Inter-app dependencies:** Coordinates with `apps.activities` for activity sessions, `apps.users` for ownership, and possibly `apps.responses` for completion unlocking.
+- **External services:** None directly, though quest templates may reference external content via JSON.
+- **Shared libraries:** Uses DRF viewsets, nested routers, and serializer patterns consistent with other apps.
+
+## Operational Notes
+- **Statefulness:** Maintains overlapping legacy and V2 data models; migrations/commands manage conversions but risk duplication.
+- **Security & privacy:** Permission checks rely on ownership; template sharing/rescoping lacks explicit organization filtering.
+- **Observability:** Limited logging; progress/completion metrics not surfaced beyond API responses.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Coexistence of legacy personal quests and V2 enrollment-based templates with bridging utilities.
+- **Planned migrations:** Comments and presence of V2 modules indicate an ongoing migration to template/enrollment architecture.
+- **Open questions:** Migration timeline, duplication handling between versions, and how quest progress ties into activities/courses.

--- a/docs/apps/responses/RECOMMENDATIONS.md
+++ b/docs/apps/responses/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Responses App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🟠 Yellow — robust session tracking but critical logic lives in models with minimal tests and unclear ownership of agenda parsing.
+- **Top risks:** Agenda markdown drift leading to stale sessions, unrestricted character selection leading to inconsistent analytics, and storage of sensitive transcripts without retention policies.
+- **Immediate wins:** Centralize agenda versioning with courses, enforce consistent character options, and add tests for session creation/logging flows.
+
+## Architecture & Design
+- **Boundaries:** Define whether agenda parsing stays here or moves to courses; encapsulate parsing in a dedicated service with clear interfaces.
+- **Domain model:** Normalize conversation storage (e.g., separate transcript table or integrate with chat app) and enforce constraints on status transitions.
+- **State management:** Replace ad hoc JSON snapshots with explicit version references; provide automated migration tools when agendas change.
+
+## Code Quality & Testing
+- **Testing strategy:** Build factories for sessions/responses, cover `CourseSessionViewSet` actions, and add regression tests for agenda hash detection.
+- **Modularity:** Extract unlocking logic into a domain service to reduce coupling with courses; decouple conversation summarization from models.
+- **Error handling:** Improve validation when agenda parsing fails and surface actionable errors rather than silent fallbacks.
+
+## API & Integration Surface
+- **Contracts:** Document API payloads for logging responses and retrieving sessions; version endpoints if schema evolves.
+- **Security:** Apply stricter permissions (organization scoping, rate limits) and define retention/anonymization policies for stored transcripts.
+- **Performance:** Prefetch responses when serializing sessions to avoid repeated queries; consider pagination for long transcripts.
+
+## Operations & Tooling
+- **Monitoring:** Track session completion rates, agenda mismatch counts, and response logging errors.
+- **Automation:** Provide management commands to reconcile sessions when agendas change and to purge stale transcripts per policy.
+- **Documentation:** Publish guidance on agenda authoring, schema evolution, and how responses feed course unlocks.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Align with courses on agenda versioning, add API documentation/tests, and enforce character choices.
+2. **Next (1-2 months):** Introduce migration tools for agenda changes, refactor conversation storage, and add observability.
+3. **Later (Quarter+):** Integrate with activities' submission model and explore analytics exports for learning outcomes.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Coordinate with courses and chat teams on agenda ownership and transcript retention.
+- **Blocking issues:** Need policy decisions on transcript storage and anonymization before implementing retention jobs.
+- **Definition of done:** Sessions stay in sync with agendas, unlocking logic is tested, and data retention/security policies are enforced.

--- a/docs/apps/responses/SUMMARY.md
+++ b/docs/apps/responses/SUMMARY.md
@@ -1,0 +1,37 @@
+# Responses App Summary
+
+## Purpose & Scope
+- **Primary mission:** Capture AI-assisted course assessment sessions, persist question-level responses, and generate conversational transcripts tied to course agendas.
+- **Core consumers:** Frontend assessment experience, courses app for progress unlocking, and analytics/reporting features requiring detailed response data.
+- **Key entry points:** `CourseSessionViewSet` in `views.py` with custom actions (create/continue sessions, log responses, finalize sessions), supporting serializers, and utilities for parsing agenda markdown (`utils.py`).
+
+## Domain Model
+- **Primary models:** `CourseSession` tracks per-user course attempts with agenda snapshots and progress metrics; `QuestionResponse` stores question-level outcomes; `ConversationTurn` captures AI conversation history (`models.py`).
+- **Supporting data:** Helpers for hashing agendas, tracking schema drift, and unlocking child courses via `Course` relationships (`models.py`).
+- **External relationships:** Strong dependency on `apps.courses.Course` for agenda content and unlocking; updates `UserCourseProgress` on completion.
+
+## Application Structure
+- **API layer:** DRF `CourseSessionViewSet` with numerous custom actions for session lifecycle and conversation management (`views.py`); URL routing exposes nested operations (`urls.py`).
+- **Business logic:** Heavy model methods handle agenda parsing, progress updates, and unlocking; view helpers orchestrate serialization/responses.
+- **Background/operations:** No scheduled jobs; relies on on-demand updates and agenda hash comparisons to detect outdated sessions.
+- **Configuration:** Hardcodes characters (e.g., `minu`) and progression logic within models/views.
+
+## Data & Control Flow
+- **Inbound:** Authenticated clients create or resume sessions, send question responses, and request conversation summaries.
+- **Processing:** Agenda markdown is parsed into structured JSON at session creation; responses update progress metrics and may trigger course unlocks.
+- **Outbound:** Responses provide serialized session state, completion percentages, conversation transcripts, and agenda snapshots for UI rendering.
+
+## Integration Points
+- **Inter-app dependencies:** Directly manipulates `apps.courses.UserCourseProgress`; interacts with chat/LLM services indirectly via stored conversation data.
+- **External services:** None directly; assumes upstream chat/LLM pipeline already executed.
+- **Shared libraries:** Utilizes DRF, Django ORM, and internal utilities for markdown parsing.
+
+## Operational Notes
+- **Statefulness:** Maintains session state with agenda snapshots; tracks schema drift but requires manual intervention when agendas change.
+- **Security & privacy:** Stores raw AI responses and agenda data; lacks explicit PII handling though content may contain user input.
+- **Observability:** Minimal logging/metrics; relies on status fields to infer progress.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Supports character variants via `character_used` and conversation logging; potential expansion to multiple assessment types.
+- **Planned migrations:** Agenda hash fields suggest planned schema evolution handling but no automated migration workflows.
+- **Open questions:** Ownership of agenda parsing, retention of conversation transcripts, and alignment with activities' session/submission model.

--- a/docs/apps/users/RECOMMENDATIONS.md
+++ b/docs/apps/users/RECOMMENDATIONS.md
@@ -1,0 +1,36 @@
+# Users App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** 🟠 Yellow — core auth works but synchronous quest onboarding, minimal rate limiting, and unclear encryption practices pose risks.
+- **Top risks:** Registration depends on quests V2 code path (potentially slow/failure-prone), SimpleJWT endpoints lack throttling, and encryption keys/storage are unspecified.
+- **Immediate wins:** Add rate limiting to auth endpoints, move quest initialization to an asynchronous job or guarded service, and document encryption key management.
+
+## Architecture & Design
+- **Boundaries:** Decouple quest onboarding from user creation by emitting a post-registration signal consumed by quests.
+- **Domain model:** Formalize encrypted PII handling with dedicated model/field classes and rotation strategies; ensure profile photos respect storage policies.
+- **State management:** Store audit timestamps for last login/profile update; integrate with organizations to ensure default org is consistent.
+
+## Code Quality & Testing
+- **Testing strategy:** Add tests for registration/login/profile flows including quest initialization failure scenarios; use factories for user creation.
+- **Modularity:** Convert function-based views to class-based ViewSets for consistency with other apps; consolidate serializer validation.
+- **Error handling:** Handle quest initialization errors gracefully (queue retry) and surface actionable error messages.
+
+## API & Integration Surface
+- **Contracts:** Document auth endpoints, token formats, and profile payloads; consider versioning for future SSO additions.
+- **Security:** Enforce password policies (already partly via validators) and add throttling/captcha to mitigate brute force; ensure logout blacklisting is idempotent.
+- **Performance:** Avoid synchronous calls to quests during registration; prefetch organization data when returning admin info.
+
+## Operations & Tooling
+- **Monitoring:** Track login/register success/failure metrics, quest onboarding latency, and encryption errors.
+- **Automation:** Provide management commands for user import/export, password resets, and encryption key rotation.
+- **Documentation:** Maintain runbooks for token revocation, password resets, and handling compromised credentials.
+
+## Suggested Roadmap
+1. **Now (0-2 weeks):** Implement throttling, decouple quest onboarding, and write regression tests for auth flows.
+2. **Next (1-2 months):** Introduce structured encryption key management and audit logging for profile changes.
+3. **Later (Quarter+):** Add SSO/social login support and advanced account management tooling.
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** Align with quests on onboarding workflow changes and with security on encryption/key storage.
+- **Blocking issues:** Need infrastructure support for secure key storage (e.g., KMS) before finalizing encryption strategy.
+- **Definition of done:** Auth endpoints hardened with throttling/logging, quest onboarding asynchronous, and encryption documented/tested.

--- a/docs/apps/users/SUMMARY.md
+++ b/docs/apps/users/SUMMARY.md
@@ -1,0 +1,37 @@
+# Users App Summary
+
+## Purpose & Scope
+- **Primary mission:** Provide custom email-based authentication, JWT token issuance, and profile management for the platform's user base.
+- **Core consumers:** Authentication flows (register/login/logout), profile editors, and other apps needing user metadata or admin helpers.
+- **Key entry points:** Function-based DRF views in `views.py` for register/login/profile/logout, serializers for auth/profile data, and the custom `User` model with helper methods (`models.py`).
+
+## Domain Model
+- **Primary models:** Custom `User` extending `AbstractUser` with email as username, anonymized identifiers, profile fields, and encrypted PII storage (`models.py`).
+- **Supporting data:** `UserManager` implements email-based creation; `encryption.py` provides wrapper for encrypting sensitive data; management commands support admin bootstrap.
+- **External relationships:** Links to `organizations.Organization` via `default_organization` and many-to-many admin relation; quests initialization invoked during user creation.
+
+## Application Structure
+- **API layer:** Function-based API endpoints using DRF decorators for register/login/profile/logout, returning JWT tokens via SimpleJWT (`views.py`).
+- **Business logic:** Serializers handle validation, quest onboarding (`UserRegistrationSerializer`), and profile updates; model methods expose helper functions for names, anonymity, and organization admin features.
+- **Background/operations:** Registration triggers quest initialization logic; management commands exist for superuser/admin tasks.
+- **Configuration:** Relies on SimpleJWT settings, environment-specific storage for profile photos, and encryption secret management.
+
+## Data & Control Flow
+- **Inbound:** Anonymous register/login requests, authenticated profile fetch/update calls, and logout token blacklist requests.
+- **Processing:** Serializers validate credentials, create users via custom manager, trigger quest initialization, and optionally encrypt PII.
+- **Outbound:** Returns JWT tokens, serialized user/profile data, and confirmation messages for logout.
+
+## Integration Points
+- **Inter-app dependencies:** Tightly coupled with `apps.quests` for default quest enrollment during registration and with `apps.organizations` for admin helpers.
+- **External services:** Uses SimpleJWT for token handling and relies on encryption utilities for PII management.
+- **Shared libraries:** Standard DRF/Serializer patterns plus Django authentication base classes.
+
+## Operational Notes
+- **Statefulness:** Stores encrypted PII as text; quest initialization runs synchronously during registration (potential latency risk).
+- **Security & privacy:** Custom encryption wrapper handles PII but key management unspecified; login endpoint uses SimpleJWT but lacks rate limiting.
+- **Observability:** Logging exists during quest initialization but overall auth events lack structured metrics/auditing.
+
+## Known Variants & Roadmaps
+- **Alternate flows:** Potential for social/SSO integration; quest initialization currently hard-coded to V2 defaults.
+- **Planned migrations:** Comments hint at future encrypted PII expansion but no roadmap provided.
+- **Open questions:** How encryption keys are managed, how to handle failed quest initialization gracefully, and whether to adopt class-based views/viewsets for consistency.

--- a/docs/templates/app_recommendations_template.md
+++ b/docs/templates/app_recommendations_template.md
@@ -1,0 +1,36 @@
+# {APP_NAME} App Recommendations
+
+## Snapshot Assessment
+- **Overall health:** {Red/Yellow/Green with justification.}
+- **Top risks:** {Greatest threats to stability, security, or delivery.}
+- **Immediate wins:** {Low-effort actions that improve quality quickly.}
+
+## Architecture & Design
+- **Boundaries:** {Changes to tighten ownership, decouple concerns, or remove duplication.}
+- **Domain model:** {Schema changes, migrations, normalization opportunities.}
+- **State management:** {Session handling, caching, lifecycle policies to revisit.}
+
+## Code Quality & Testing
+- **Testing strategy:** {Unit/integration coverage, fixtures, factories.}
+- **Modularity:** {Refactors for services, serializers, viewsets.}
+- **Error handling:** {Validation, exception surfaces, user feedback loops.}
+
+## API & Integration Surface
+- **Contracts:** {Versioning, schema documentation, compatibility layers.}
+- **Security:** {AuthZ/authN, rate limiting, input sanitization.}
+- **Performance:** {N+1 queries, pagination, bulk operations.}
+
+## Operations & Tooling
+- **Monitoring:** {Logging, metrics, alerting gaps.}
+- **Automation:** {Management commands, background jobs, scheduled tasks.}
+- **Documentation:** {What should live in README, ADRs, or runbooks.}
+
+## Suggested Roadmap
+1. **{Now (0-2 weeks)}:** {Critical fixes or foundational tasks.}
+2. **{Next (1-2 months)}:** {Structural improvements, migrations, tooling.}
+3. **{Later (Quarter+)}:** {Strategic investments, new capabilities.}
+
+## Dependencies & Follow-Ups
+- **Cross-team coordination:** {Stakeholders or services impacted by changes.}
+- **Blocking issues:** {Prerequisites such as data cleanup or infrastructure.}
+- **Definition of done:** {Acceptance criteria to consider this area healthy.}

--- a/docs/templates/app_summary_template.md
+++ b/docs/templates/app_summary_template.md
@@ -1,0 +1,37 @@
+# {APP_NAME} App Summary
+
+## Purpose & Scope
+- **Primary mission:** {One-sentence description of what the app owns.}
+- **Core consumers:** {Internal Django apps, API clients, background jobs, etc.}
+- **Key entry points:** {REST endpoints, signals, Celery tasks, management commands.}
+
+## Domain Model
+- **Primary models:** {List the core models and their responsibilities.}
+- **Supporting data:** {Auxiliary tables, through models, enums/constants.}
+- **External relationships:** {Cross-app foreign keys, external APIs, third-party services.}
+
+## Application Structure
+- **API layer:** {Views/ViewSets, routers, DRF serializers exposed.}
+- **Business logic:** {Services, utils, workflow managers that encapsulate rules.}
+- **Background/operations:** {Management commands, scheduled jobs, signals.}
+- **Configuration:** {Settings, feature flags, environment variables the app relies on.}
+
+## Data & Control Flow
+- **Inbound:** {How data enters the app and validation performed.}
+- **Processing:** {How requests are orchestrated across modules.}
+- **Outbound:** {How responses/events leave the app and who consumes them.}
+
+## Integration Points
+- **Inter-app dependencies:** {How this app coordinates with other Django apps.}
+- **External services:** {LLM providers, storage buckets, messaging systems, etc.}
+- **Shared libraries:** {Utilities shared across apps.}
+
+## Operational Notes
+- **Statefulness:** {Session handling, caching, long-running resources.}
+- **Security & privacy:** {Sensitive data handling, permission layers.}
+- **Observability:** {Logging, analytics, feature flags.}
+
+## Known Variants & Roadmaps
+- **Alternate flows:** {Legacy vs. new implementations, feature flags.}
+- **Planned migrations:** {Schema or architecture work already hinted at in code.}
+- **Open questions:** {Important unknowns for future maintainers.}

--- a/docs/templates/project_recommendations_template.md
+++ b/docs/templates/project_recommendations_template.md
@@ -1,0 +1,31 @@
+# Project Recommendations
+
+## Executive Summary
+- **Overall health:** {Red/Yellow/Green with rationale.}
+- **Critical themes:** {3-5 cross-cutting issues to address.}
+- **Success criteria:** {Definition of done for the remediation effort.}
+
+## Architecture & Platform
+- **App boundaries:** {Restructuring, modularization, ownership decisions.}
+- **Infrastructure:** {Hosting, CI/CD, secrets, environment parity.}
+- **Data strategy:** {Database management, migrations, retention policies.}
+
+## Product Surface
+- **API governance:** {Versioning, documentation, client contracts.}
+- **User experience:** {Session handling, realtime features, access controls.}
+- **Compliance & privacy:** {PII handling, auditing, regulatory obligations.}
+
+## Engineering Excellence
+- **Testing:** {Unit/integration/e2e coverage targets and tooling.}
+- **Observability:** {Logging, metrics, tracing, incident response.}
+- **Developer experience:** {Local setup, linters, code review guidelines.}
+
+## Roadmap
+1. **Foundation (0-2 weeks):** {Immediate fixes, guardrails, alignment.}
+2. **Stabilization (1-2 months):** {Structural improvements, automation, documentation.}
+3. **Maturation (Quarter+):** {Long-term initiatives, platform investments.}
+
+## Ownership & Follow-Through
+- **Team assignments:** {Who drives each theme.}
+- **Dependencies:** {External partners, budget, procurement.}
+- **Tracking:** {Suggested rituals, dashboards, or KPI cadence.}

--- a/docs/templates/project_summary_template.md
+++ b/docs/templates/project_summary_template.md
@@ -1,0 +1,31 @@
+# Project Overview
+
+## Vision & Scope
+- **Product intent:** {High-level goal and target users.}
+- **System boundaries:** {What lives in this repo vs external services.}
+- **Deployment targets:** {Environments, hosting platforms, CI/CD.}
+
+## Application Map
+- **Installed Django apps:** {List with one-line responsibilities.}
+- **Shared libraries:** {Cross-cutting utilities, middleware, signals.}
+- **External integrations:** {LLMs, storage, authentication providers, analytics.}
+
+## Runtime Architecture
+- **Request lifecycle:** {ASGI/WSGI entrypoints, middleware, routers.}
+- **Data layer:** {Database(s), caching, messaging.}
+- **Background work:** {Scheduled tasks, management commands, async workers.}
+
+## Configuration & Environments
+- **Settings strategy:** {Base/local/prod split, environment variable usage.}
+- **Secrets management:** {Where secrets live, rotation policies.}
+- **Feature flags:** {Runtime toggles, configuration stores.}
+
+## Operational Considerations
+- **Security posture:** {Authentication, authorization, multi-tenant boundaries.}
+- **Observability:** {Logging, monitoring, error reporting.}
+- **Scalability:** {Stateful components, concurrency limits, horizontal scaling.}
+
+## Current Initiatives
+- **Active migrations/refactors:** {In-flight architecture changes.}
+- **Known gaps:** {Documentation, testing, tooling debt.}
+- **Opportunities:** {Areas for investment or simplification.}


### PR DESCRIPTION
## Summary
- add reusable templates for app and project level audit documentation
- document each Django app with standardized summaries and recommendations
- provide project-wide overview and remediation roadmap for the platform

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dc32778e188330a3dda331c0abbec3